### PR TITLE
Update app-1713693601-data-access.tsx

### DIFF
--- a/web/components/app-1713693601/app-1713693601-data-access.tsx
+++ b/web/components/app-1713693601/app-1713693601-data-access.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { App1713693601IDL, getApp1713693601ProgramId } from '@app-1713693601/anchor'
+import { App1713693601IDL, getApp1713693601ProgramId ,App1713693601} from '@app-1713693601/anchor'
 import { Program } from '@coral-xyz/anchor'
 import { useConnection } from '@solana/wallet-adapter-react'
 import { Cluster, Keypair, PublicKey } from '@solana/web3.js'
@@ -17,7 +17,7 @@ export function useApp1713693601Program() {
   const transactionToast = useTransactionToast()
   const provider = useAnchorProvider()
   const programId = useMemo(() => getApp1713693601ProgramId(cluster.network as Cluster), [cluster])
-  const program = new Program(App1713693601IDL, programId, provider)
+  const program = new Program(App1713693601IDL as App1713693601, provider)
 
   const accounts = useQuery({
     queryKey: ['app-1713693601', 'all', { cluster }],


### PR DESCRIPTION
Update the solana-dapp-anchor to match the current update in the version 0.30.0 coral npm. 
There is no need to pass a program ID in the new provider contructor according to the upgrade in the version 0.30.0 of the coral anchor because it is being accessed directly from the IDL, this can be seen in the coral [github link](https://github.com/acheroncrypto/anchor/blob/f0b29111/ts/packages/anchor/src/program/index.ts#L295)